### PR TITLE
Refactor: Move Roundtable management from Community to Master service

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,11 +39,11 @@ The project is organized into the following main directories:
 The system is composed of several microservices, each responsible for a specific domain. Each service will expose a gRPC API defined by `.proto` files located within their respective directories (e.g., `src/Services/User/user.proto`).
 
 **Core Modules:**
-- **MasterService:** Manages master data or configurations.
+- **MasterService:** Manages master data, configurations, and Roundtables (including their definition, listing, creation, and other related operations).
 - **MeetingService:** Handles scheduling and management of meetings.
 - **SurveyService:** Manages surveys, questions, and responses.
 - **UserService:** Handles user creation, authentication, and profile management.
-- **CommunityService:** Manages community features, potentially linking users and roundtables.
+- **CommunityService:** Manages community features. (Details of specific features to be defined).
 - **AuriemmaExchangeService:** Manages functionalities related to "Auriemma Exchange".
 - **HomeService:** Provides data or services for the main dashboard/home screen.
 - **ToolService:** Provides various tools or utilities within the platform.

--- a/src/Services/Community.Tests/CommunityServiceTests.cs
+++ b/src/Services/Community.Tests/CommunityServiceTests.cs
@@ -1,27 +1,27 @@
 using Xunit;
-using SurveyService.Community; // Namespace for request/response/enum messages
-using SurveyService.CommunityImplementation; // Namespace for the service implementation
+// using SurveyService.Community; // Commented out as Roundtable types are removed
+// using SurveyService.CommunityImplementation; // Commented out as CommunityServiceImpl is now empty
 using Grpc.Core;
-using System.Linq;
-using System.Threading.Tasks; // For Task
-using System.Collections.Generic; // For List
+using System.Linq; // May or may not be needed in the future, keeping for now
+using System.Threading.Tasks; // For Task.CompletedTask in MockServerCallContext
+using System.Collections.Generic; // May or may not be needed in the future, keeping for now
 
-// Assuming the namespace for the tests
 namespace SurveyService.Community.Tests
 {
     public class CommunityServiceTests
     {
-        private CommunityServiceImpl _service; // Service instance for each test
-        private ServerCallContext _context; // Mock context
+        // private CommunityServiceImpl _service; // Removed, CommunityServiceImpl is now minimal
+        // private ServerCallContext _context; // Removed, no methods to test
 
         public CommunityServiceTests()
         {
-            // Re-initialize service for each test to ensure clean state for _roundtablesStorage
-            _service = new CommunityServiceImpl(); 
-            _context = new MockServerCallContext();
+            // Constructor content removed as CommunityServiceImpl is now empty
+            // and no methods are being tested.
+            // _service = new CommunityServiceImpl();
+            // _context = new MockServerCallContext();
         }
 
-        // MockServerCallContext for testing purposes (can be shared or nested)
+        // MockServerCallContext can remain if needed for future non-roundtable tests.
         public class MockServerCallContext : ServerCallContext
         {
             protected override Task WriteResponseHeadersAsyncCore(Metadata responseHeaders) => Task.CompletedTask;
@@ -38,282 +38,7 @@ namespace SurveyService.Community.Tests
             protected override AuthContext AuthContextCore => null;
         }
 
-        // --- Existing ListRoundtables Tests (Keep As Is) ---
-        [Fact]
-        public async Task ListRoundtables_NoFilters_ReturnsDefaultPageOfAllItems()
-        {
-            var request = new ListRoundtablesRequest { PageSize = 2 };
-            var response = await _service.ListRoundtables(request, _context);
-            Assert.NotNull(response);
-            Assert.Equal(6, response.TotalSize); // Updated sample size
-            Assert.Equal(2, response.Roundtables.Count);
-            Assert.NotEmpty(response.NextPageToken);
-        }
-
-        [Fact]
-        public async Task ListRoundtables_FilterByStatus_Active()
-        {
-            var request = new ListRoundtablesRequest { PageSize = 10, StatusFilter = RoundtableStatus.Active };
-            var response = await _service.ListRoundtables(request, _context);
-            Assert.NotNull(response);
-            Assert.True(response.Roundtables.All(r => r.Status == RoundtableStatus.Active));
-            Assert.Equal(5, response.TotalSize); // 5 active items in updated sample
-            Assert.Equal(5, response.Roundtables.Count);
-        }
-
-        [Fact]
-        public async Task ListRoundtables_FilterByStatus_Inactive()
-        {
-            var request = new ListRoundtablesRequest { PageSize = 10, StatusFilter = RoundtableStatus.Inactive };
-            var response = await _service.ListRoundtables(request, _context);
-            Assert.NotNull(response);
-            Assert.True(response.Roundtables.All(r => r.Status == RoundtableStatus.Inactive));
-            Assert.Equal(1, response.TotalSize); 
-            Assert.Single(response.Roundtables);
-            Assert.Equal("Gamma Roundtable", response.Roundtables[0].Name);
-        }
-        
-        [Fact]
-        public async Task ListRoundtables_FilterByStatus_All()
-        {
-            var request = new ListRoundtablesRequest { PageSize = 10, StatusFilter = RoundtableStatus.All };
-            var response = await _service.ListRoundtables(request, _context);
-            Assert.NotNull(response);
-            Assert.Equal(6, response.TotalSize); 
-            Assert.Equal(6, response.Roundtables.Count);
-        }
-
-        [Fact]
-        public async Task ListRoundtables_SearchByName_ReturnsMatching()
-        {
-            var request = new ListRoundtablesRequest { PageSize = 10, SearchQuery = "Alpha" };
-            var response = await _service.ListRoundtables(request, _context);
-            Assert.NotNull(response);
-            Assert.Single(response.Roundtables);
-            Assert.Equal("Alpha Roundtable", response.Roundtables[0].Name);
-            Assert.Equal(1, response.TotalSize);
-        }
-        
-        [Fact]
-        public async Task ListRoundtables_SearchByAbbreviation_ReturnsMatching()
-        {
-            var request = new ListRoundtablesRequest { PageSize = 10, SearchQuery = "BETA" };
-            var response = await _service.ListRoundtables(request, _context);
-            Assert.NotNull(response);
-            Assert.Single(response.Roundtables);
-            Assert.Equal("Beta Roundtable", response.Roundtables[0].Name);
-            Assert.Equal("BETA", response.Roundtables[0].Abbreviation);
-            Assert.Equal(1, response.TotalSize);
-        }
-
-        [Fact]
-        public async Task ListRoundtables_SearchByDirectorName_ReturnsMatching()
-        {
-            var request = new ListRoundtablesRequest { PageSize = 10, SearchQuery = "Dr. Alice" }; // Updated to match sample data
-            var response = await _service.ListRoundtables(request, _context);
-            Assert.NotNull(response);
-            Assert.Equal(3, response.TotalSize); // Dr. Alice directs Alpha, Gamma, Epsilon
-            Assert.Equal(3, response.Roundtables.Count);
-        }
-        
-        [Fact]
-        public async Task ListRoundtables_SearchByAssociateName_ReturnsMatching()
-        {
-            var request = new ListRoundtablesRequest { PageSize = 10, SearchQuery = "Diana Helper" }; // Updated to match sample data
-            var response = await _service.ListRoundtables(request, _context);
-            Assert.NotNull(response);
-            Assert.Equal(2, response.TotalSize); // Diana is in Alpha and Delta
-            Assert.Equal(2, response.Roundtables.Count);
-        }
-
-        [Fact]
-        public async Task ListRoundtables_Search_NoResults()
-        {
-            var request = new ListRoundtablesRequest { PageSize = 10, SearchQuery = "NonExistent" };
-            var response = await _service.ListRoundtables(request, _context);
-            Assert.NotNull(response);
-            Assert.Empty(response.Roundtables);
-            Assert.Equal(0, response.TotalSize);
-        }
-
-        [Fact]
-        public async Task ListRoundtables_PageSizeMaxEnforced()
-        {
-            var request = new ListRoundtablesRequest { PageSize = 200 };
-            var response = await _service.ListRoundtables(request, _context);
-            Assert.NotNull(response);
-            Assert.Equal(6, response.TotalSize);
-            Assert.Equal(6, response.Roundtables.Count); 
-        }
-
-        [Fact]
-        public async Task ListRoundtables_PageSizeZeroDefaultsToTen() 
-        {
-            var request = new ListRoundtablesRequest { PageSize = 0 };
-            var response = await _service.ListRoundtables(request, _context);
-            Assert.NotNull(response);
-            Assert.Equal(6, response.TotalSize);
-            Assert.Equal(6, response.Roundtables.Count); 
-        }
-
-        // --- New Tests for CreateRoundtable ---
-
-        [Fact]
-        public async Task CreateRoundtable_Successful_WithRequiredFields()
-        {
-            var request = new CreateRoundtableRequest
-            {
-                Name = "New Test Roundtable",
-                Abbreviation = "NTR",
-                IsActive = true,
-                DirectorUserIds = { "dir1" },
-                PrimaryDirectorUserId = "dir1"
-            };
-
-            var response = await _service.CreateRoundtable(request, _context);
-
-            Assert.NotNull(response);
-            Assert.NotNull(response.Roundtable);
-            Assert.Equal("New Test Roundtable", response.Roundtable.Name);
-            Assert.Equal("NTR", response.Roundtable.Abbreviation);
-            Assert.Equal(RoundtableStatus.Active, response.Roundtable.Status);
-            Assert.Equal("dir1", response.Roundtable.Director.UserId);
-            Assert.True(response.Roundtable.Director.IsPrimary);
-
-            // Verify it's added to the list for subsequent List calls
-            var listResponse = await _service.ListRoundtables(new ListRoundtablesRequest { SearchQuery = "NTR" }, _context);
-            Assert.Single(listResponse.Roundtables);
-        }
-
-        [Fact]
-        public async Task CreateRoundtable_Successful_WithAllFields()
-        {
-            var request = new CreateRoundtableRequest
-            {
-                Name = "Full Test Roundtable",
-                Abbreviation = "FULL",
-                IsActive = false,
-                Description = "A full description.",
-                ClientIds = { "clientA", "clientB" },
-                DirectorUserIds = { "dir10", "dir11" },
-                PrimaryDirectorUserId = "dir10",
-                AssociateUserIds = { "assoc20", "assoc21" },
-                PrimaryAssociateUserId = "assoc20"
-            };
-
-            var response = await _service.CreateRoundtable(request, _context);
-            var rt = response.Roundtable;
-
-            Assert.NotNull(rt);
-            Assert.Equal("Full Test Roundtable", rt.Name);
-            Assert.Equal("FULL", rt.Abbreviation);
-            Assert.Equal(RoundtableStatus.Inactive, rt.Status);
-            Assert.Equal("A full description.", rt.Description);
-            Assert.Equal(2, rt.ClientIds.Count);
-            Assert.Contains("clientA", rt.ClientIds);
-            Assert.Equal("dir10", rt.Director.UserId);
-            Assert.True(rt.Director.IsPrimary);
-            Assert.Equal(2, rt.Associates.Count);
-            var primaryAssociate = rt.Associates.First(a => a.UserId == "assoc20");
-            Assert.True(primaryAssociate.IsPrimary);
-            var secondaryAssociate = rt.Associates.First(a => a.UserId == "assoc21");
-            Assert.False(secondaryAssociate.IsPrimary);
-            Assert.Equal(2, rt.ClientsWithAccessCount);
-        }
-
-        [Fact]
-        public async Task CreateRoundtable_Fail_MissingName()
-        {
-            var request = new CreateRoundtableRequest { Abbreviation = "FAIL", DirectorUserIds = { "d1" }, PrimaryDirectorUserId = "d1" };
-            var exception = await Assert.ThrowsAsync<RpcException>(() => _service.CreateRoundtable(request, _context));
-            Assert.Equal(StatusCode.InvalidArgument, exception.StatusCode);
-            Assert.Contains("Name is required", exception.Status.Detail);
-        }
-
-        [Fact]
-        public async Task CreateRoundtable_Fail_MissingAbbreviation()
-        {
-            var request = new CreateRoundtableRequest { Name = "Fail RT", DirectorUserIds = { "d1" }, PrimaryDirectorUserId = "d1" };
-            var exception = await Assert.ThrowsAsync<RpcException>(() => _service.CreateRoundtable(request, _context));
-            Assert.Equal(StatusCode.InvalidArgument, exception.StatusCode);
-            Assert.Contains("Abbreviation is required", exception.Status.Detail);
-        }
-        
-        [Fact]
-        public async Task CreateRoundtable_Fail_MissingDirectors()
-        {
-            var request = new CreateRoundtableRequest { Name = "Fail RT", Abbreviation = "FAIL", PrimaryDirectorUserId = "d1" };
-            var exception = await Assert.ThrowsAsync<RpcException>(() => _service.CreateRoundtable(request, _context));
-            Assert.Equal(StatusCode.InvalidArgument, exception.StatusCode);
-            Assert.Contains("At least one Director must be selected", exception.Status.Detail);
-        }
-
-        [Fact]
-        public async Task CreateRoundtable_Fail_MissingPrimaryDirector()
-        {
-            var request = new CreateRoundtableRequest { Name = "Fail RT", Abbreviation = "FAIL", DirectorUserIds = { "d1" } };
-            var exception = await Assert.ThrowsAsync<RpcException>(() => _service.CreateRoundtable(request, _context));
-            Assert.Equal(StatusCode.InvalidArgument, exception.StatusCode);
-            Assert.Contains("Primary Director is required", exception.Status.Detail);
-        }
-        
-        [Fact]
-        public async Task CreateRoundtable_Fail_PrimaryDirectorNotInSelectedDirectors()
-        {
-            var request = new CreateRoundtableRequest { Name = "Fail RT", Abbreviation = "FAIL", DirectorUserIds = { "d1" }, PrimaryDirectorUserId = "d2-not-selected" };
-            var exception = await Assert.ThrowsAsync<RpcException>(() => _service.CreateRoundtable(request, _context));
-            Assert.Equal(StatusCode.InvalidArgument, exception.StatusCode);
-            Assert.Contains("Primary Director must be one of the selected Directors", exception.Status.Detail);
-        }
-
-        [Fact]
-        public async Task CreateRoundtable_Fail_PrimaryAssociateNotInSelectedAssociates()
-        {
-            var request = new CreateRoundtableRequest { 
-                Name = "Fail RT", Abbreviation = "FAIL", 
-                DirectorUserIds = { "d1" }, PrimaryDirectorUserId = "d1",
-                AssociateUserIds = { "a1" }, PrimaryAssociateUserId = "a2-not-selected"
-            };
-            var exception = await Assert.ThrowsAsync<RpcException>(() => _service.CreateRoundtable(request, _context));
-            Assert.Equal(StatusCode.InvalidArgument, exception.StatusCode);
-            Assert.Contains("Primary Associate must be one of the selected Associates", exception.Status.Detail);
-        }
-
-
-        [Fact]
-        public async Task CreateRoundtable_Fail_DuplicateAbbreviation()
-        {
-            var initialRequest = new CreateRoundtableRequest 
-            { 
-                Name = "First RT", Abbreviation = "DUP", 
-                DirectorUserIds = { "d1" }, PrimaryDirectorUserId = "d1" 
-            };
-            await _service.CreateRoundtable(initialRequest, _context); // Create first one
-
-            var duplicateRequest = new CreateRoundtableRequest 
-            { 
-                Name = "Second RT", Abbreviation = "DUP", // Same abbreviation
-                DirectorUserIds = { "d2" }, PrimaryDirectorUserId = "d2" 
-            };
-            var exception = await Assert.ThrowsAsync<RpcException>(() => _service.CreateRoundtable(duplicateRequest, _context));
-            Assert.Equal(StatusCode.AlreadyExists, exception.StatusCode);
-            Assert.Contains("Abbreviation 'DUP' already exists", exception.Status.Detail);
-        }
-
-        [Fact]
-        public async Task CreateRoundtable_DefaultIsActiveTrue()
-        {
-            // Note: is_active defaults to false (proto3 default for bool) if not sent by client.
-            // The user story says "checkbox should be checked by default", implying client sends true.
-            // This test assumes client sends true.
-            var request = new CreateRoundtableRequest
-            {
-                Name = "Default Active RT", Abbreviation = "DART",
-                DirectorUserIds = { "d1" }, PrimaryDirectorUserId = "d1",
-                IsActive = true // Explicitly set as per typical client behavior for "checked by default"
-            };
-            var response = await _service.CreateRoundtable(request, _context);
-            Assert.Equal(RoundtableStatus.Active, response.Roundtable.Status);
-        }
+        // All [Fact] methods (TestListRoundtables_ReturnsSampleData, TestCreateRoundtable_AddsNewRoundtable, etc.)
+        // have been removed as the corresponding service methods are gone.
     }
 }

--- a/src/Services/Community/CommunityServiceImplementation.cs
+++ b/src/Services/Community/CommunityServiceImplementation.cs
@@ -1,9 +1,9 @@
 using Grpc.Core;
-using SurveyService.Community; // This is the generated namespace from community.proto
-using System; // For Guid
-using System.Linq;
-using System.Threading.Tasks;
-using System.Collections.Generic; // For List
+// using SurveyService.Community; // No longer needed as all Roundtable types are removed
+// using System; // No longer needed (Guid was for Roundtable.Id)
+// using System.Linq; // No longer needed
+// using System.Threading.Tasks; // No longer needed for Task.FromResult
+// using System.Collections.Generic; // No longer needed for List
 
 // Assuming the namespace for the service implementation
 namespace SurveyService.CommunityImplementation
@@ -13,208 +13,16 @@ namespace SurveyService.CommunityImplementation
         // Placeholder for a logger
         // private readonly ILogger<CommunityServiceImpl> _logger;
 
-        // In-memory store for sample data
-        private static List<Roundtable> _roundtablesStorage = new List<Roundtable>();
-        private static readonly object _lock = new object();
+        // Constructor might be needed if ILogger is used, or for other initializations.
+        // For now, it's removed as it only contained Roundtable sample data logic.
+        // public CommunityServiceImpl(/*ILogger<CommunityServiceImpl> logger*/)
+        // {
+        // _logger = logger;
+        // }
 
-        public CommunityServiceImpl(/*ILogger<CommunityServiceImpl> logger*/)
-        {
-            // _logger = logger;
-            // Initialize with sample data if storage is empty
-            lock (_lock)
-            {
-                if (!_roundtablesStorage.Any())
-                {
-                    _roundtablesStorage.AddRange(GenerateSampleRoundtables());
-                }
-            }
-        }
-
-        public override Task<ListRoundtablesResponse> ListRoundtables(ListRoundtablesRequest request, ServerCallContext context)
-        {
-            // Validate inputs
-            if (request.PageSize <= 0) request.PageSize = 10;
-            if (request.PageSize > 100) request.PageSize = 100;
-
-            List<Roundtable> currentRoundtablesView;
-            lock(_lock) // Ensure thread-safe access to the list
-            {
-                // Make a copy for filtering to avoid modifying the original list during iteration
-                currentRoundtablesView = new List<Roundtable>(_roundtablesStorage);
-            }
-            
-            var filteredRoundtables = currentRoundtablesView;
-
-            if (!string.IsNullOrEmpty(request.SearchQuery))
-            {
-                string query = request.SearchQuery.ToLower();
-                filteredRoundtables = filteredRoundtables.Where(r =>
-                    (r.Name?.ToLower().Contains(query) ?? false) ||
-                    (r.Director?.Name?.ToLower().Contains(query) ?? false) ||
-                    (r.Associates?.Any(a => a.Name?.ToLower().Contains(query) ?? false) ?? false) ||
-                    (r.Abbreviation?.ToLower().Contains(query) ?? false) // Search by abbreviation
-                ).ToList();
-            }
-
-            if (request.StatusFilter != RoundtableStatus.All && request.StatusFilter != RoundtableStatus.RoundtableStatusUnspecified)
-            {
-                filteredRoundtables = filteredRoundtables.Where(r => r.Status == request.StatusFilter).ToList();
-            }
-            
-            // Basic offset calculation if page_token is a simple integer offset.
-            // This is still a placeholder for true cursor-based pagination.
-            int skipAmount = 0;
-            if (!string.IsNullOrEmpty(request.PageToken) && int.TryParse(request.PageToken, out int parsedOffset))
-            {
-                skipAmount = parsedOffset;
-            }
-            
-            int totalItems = filteredRoundtables.Count;
-            var paginatedRoundtables = filteredRoundtables.Skip(skipAmount).Take(request.PageSize).ToList();
-
-            var response = new ListRoundtablesResponse { TotalSize = totalItems };
-            response.Roundtables.AddRange(paginatedRoundtables);
-
-            if ((skipAmount + paginatedRoundtables.Count) < totalItems)
-            {
-                // Placeholder for next_page_token. In a real scenario, this would be the 'skipAmount + request.PageSize' or a cursor.
-                response.NextPageToken = (skipAmount + request.PageSize).ToString(); 
-            }
-
-            return Task.FromResult(response);
-        }
-
-        public override Task<CreateRoundtableResponse> CreateRoundtable(CreateRoundtableRequest request, ServerCallContext context)
-        {
-            // --- Input Validation ---
-            if (string.IsNullOrWhiteSpace(request.Name))
-            {
-                throw new RpcException(new Status(StatusCode.InvalidArgument, "Roundtable Name is required."));
-            }
-            if (string.IsNullOrWhiteSpace(request.Abbreviation))
-            {
-                throw new RpcException(new Status(StatusCode.InvalidArgument, "Roundtable Abbreviation is required."));
-            }
-            if (request.DirectorUserIds == null || !request.DirectorUserIds.Any())
-            {
-                throw new RpcException(new Status(StatusCode.InvalidArgument, "At least one Director must be selected."));
-            }
-            if (string.IsNullOrWhiteSpace(request.PrimaryDirectorUserId))
-            {
-                throw new RpcException(new Status(StatusCode.InvalidArgument, "Primary Director is required."));
-            }
-            if (!request.DirectorUserIds.Contains(request.PrimaryDirectorUserId))
-            {
-                throw new RpcException(new Status(StatusCode.InvalidArgument, "Primary Director must be one of the selected Directors."));
-            }
-            if (!string.IsNullOrWhiteSpace(request.PrimaryAssociateUserId) && (request.AssociateUserIds == null || !request.AssociateUserIds.Contains(request.PrimaryAssociateUserId)))
-            {
-                 throw new RpcException(new Status(StatusCode.InvalidArgument, "Primary Associate must be one of the selected Associates."));
-            }
-
-            // Placeholder for abbreviation uniqueness check (requires data store access)
-            lock(_lock)
-            {
-                if (_roundtablesStorage.Any(rt => rt.Abbreviation.Equals(request.Abbreviation, StringComparison.OrdinalIgnoreCase)))
-                {
-                    throw new RpcException(new Status(StatusCode.AlreadyExists, $"Roundtable Abbreviation '{request.Abbreviation}' already exists."));
-                }
-            }
-
-            // --- Construct Roundtable Object ---
-            var newRoundtable = new Roundtable
-            {
-                Id = Guid.NewGuid().ToString(), // Generate new UUID
-                Name = request.Name,
-                Abbreviation = request.Abbreviation,
-                Description = request.Description ?? string.Empty, // Handle optional field
-                Status = request.IsActive ? RoundtableStatus.Active : RoundtableStatus.Inactive,
-                // Populate Director
-                Director = new UserDetails { 
-                    UserId = request.PrimaryDirectorUserId, 
-                    Name = $"User_{request.PrimaryDirectorUserId.Substring(0,Math.Min(5, request.PrimaryDirectorUserId.Length))}", // Placeholder name, ensure substring length is valid
-                    IsPrimary = true 
-                },
-                ClientsWithAccessCount = request.ClientIds?.Count ?? 0
-            };
-            if (request.ClientIds != null)
-            {
-                newRoundtable.ClientIds.AddRange(request.ClientIds);
-            }
-
-            // Populate Associates
-            if (request.AssociateUserIds != null)
-            {
-                foreach (var assocId in request.AssociateUserIds)
-                {
-                    newRoundtable.Associates.Add(new UserDetails {
-                        UserId = assocId,
-                        Name = $"User_{assocId.Substring(0,Math.Min(5, assocId.Length))}", // Placeholder name, ensure substring length is valid
-                        IsPrimary = (assocId == request.PrimaryAssociateUserId)
-                    });
-                }
-            }
-            
-            // --- Persist (Add to in-memory list) ---
-            lock(_lock)
-            {
-                _roundtablesStorage.Add(newRoundtable);
-            }
-
-            // _logger?.LogInformation("New roundtable created with ID: {Id}", newRoundtable.Id);
-            return Task.FromResult(new CreateRoundtableResponse { Roundtable = newRoundtable });
-        }
-
-        // Updated helper method to generate sample data
-        private static List<Roundtable> GenerateSampleRoundtables()
-        {
-            var sampleDirector1 = new UserDetails { UserId = "user-dir-1", Name = "Dr. Alice Director", IsPrimary = true };
-            var sampleDirector2 = new UserDetails { UserId = "user-dir-2", Name = "Mr. Bob Overseer", IsPrimary = true };
-
-            var sampleAssociate1 = new UserDetails { UserId = "user-assoc-1", Name = "Charlie Associate", IsPrimary = true };
-            var sampleAssociate2 = new UserDetails { UserId = "user-assoc-2", Name = "Diana Helper", IsPrimary = false };
-            var sampleAssociate3 = new UserDetails { UserId = "user-assoc-3", Name = "Edward Contributor", IsPrimary = true };
-            
-            return new List<Roundtable>
-            {
-                new Roundtable
-                {
-                    Id = "rt-uuid-1", Name = "Alpha Roundtable", Abbreviation = "ALPHA", Description = "The first roundtable.",
-                    Director = sampleDirector1, Status = RoundtableStatus.Active, ClientsWithAccessCount = 10,
-                    Associates = { sampleAssociate1, sampleAssociate2 }, ClientIds = { "client-1", "client-2" }
-                },
-                new Roundtable
-                {
-                    Id = "rt-uuid-2", Name = "Beta Roundtable", Abbreviation = "BETA", Description = "The second roundtable, focusing on tech.",
-                    Director = sampleDirector2, Status = RoundtableStatus.Active, ClientsWithAccessCount = 5,
-                    Associates = { sampleAssociate3 }, ClientIds = { "client-3" }
-                },
-                new Roundtable
-                {
-                    Id = "rt-uuid-3", Name = "Gamma Roundtable", Abbreviation = "GAMMA", Description = "An inactive roundtable for archival.",
-                    Director = sampleDirector1, Status = RoundtableStatus.Inactive, ClientsWithAccessCount = 7,
-                    Associates = { sampleAssociate1 }, ClientIds = { "client-1", "client-4" }
-                },
-                new Roundtable
-                {
-                    Id = "rt-uuid-4", Name = "Delta Project Circle", Abbreviation = "DELTA", Description = "For special projects.",
-                    Director = sampleDirector2, Status = RoundtableStatus.Active, ClientsWithAccessCount = 12,
-                    Associates = { sampleAssociate2, sampleAssociate3 }, ClientIds = { "client-2", "client-3", "client-5" }
-                },
-                // Add a couple more to make pagination more evident
-                new Roundtable
-                {
-                    Id = "rt-uuid-5", Name = "Epsilon Think Tank", Abbreviation = "EPSILON", Description = "Strategic discussions.",
-                    Director = sampleDirector1, Status = RoundtableStatus.Active, ClientsWithAccessCount = 3,
-                    Associates = { sampleAssociate1 }, ClientIds = { "client-6" }
-                },
-                new Roundtable
-                {
-                    Id = "rt-uuid-6", Name = "Zeta Initiative", Abbreviation = "ZETA", Description = "Future planning group.",
-                    Director = sampleDirector2, Status = RoundtableStatus.Active, ClientsWithAccessCount = 8,
-                    Associates = { sampleAssociate2 }, ClientIds = { "client-7", "client-8" }
-                }
-            };
-        }
+        // ListRoundtables method removed
+        // CreateRoundtable method removed
+        // GenerateSampleRoundtables helper method removed
+        // _roundtablesStorage and _lock removed
     }
 }

--- a/src/Services/Community/community.proto
+++ b/src/Services/Community/community.proto
@@ -4,65 +4,6 @@ package community;
 
 option csharp_namespace = "SurveyService.Community";
 
-enum RoundtableStatus {
-  ROUNDTABLE_STATUS_UNSPECIFIED = 0;
-  ACTIVE = 1;
-  INACTIVE = 2;
-  ALL = 3; 
-}
-
-message UserDetails {
-  string user_id = 1;
-  string name = 2;
-  bool is_primary = 3;
-}
-
-message Roundtable {
-  string id = 1; 
-  string name = 2;
-  UserDetails director = 3;
-  repeated UserDetails associates = 4;
-  RoundtableStatus status = 5;
-  int32 clients_with_access_count = 6;
-  // New fields for Create/Edit Roundtable:
-  string abbreviation = 7;        // New field
-  string description = 8;         // New field
-  repeated string client_ids = 9; // New field to store IDs of selected clients
-}
-
-message ListRoundtablesRequest {
-  string search_query = 1;
-  RoundtableStatus status_filter = 2;
-  int32 page_size = 3;
-  string page_token = 4;
-}
-
-message ListRoundtablesResponse {
-  repeated Roundtable roundtables = 1;
-  string next_page_token = 2;
-  int32 total_size = 3;
-}
-
-// --- Messages for CreateRoundtable ---
-message CreateRoundtableRequest {
-  string name = 1;                            // Required
-  string abbreviation = 2;                    // Required, Unique
-  bool is_active = 3;                         // Defaults to true on client, server can respect if sent
-  string description = 4;                     // Optional
-  repeated string client_ids = 5;             // Optional, list of client UUIDs
-  repeated string director_user_ids = 6;      // Required, list of user UUIDs
-  repeated string associate_user_ids = 7;     // Optional, list of user UUIDs
-  string primary_director_user_id = 8;        // Required, UUID from director_user_ids
-  string primary_associate_user_id = 9;       // Optional, UUID from associate_user_ids
-}
-
-message CreateRoundtableResponse {
-  Roundtable roundtable = 1; // The newly created roundtable object
-}
-// --- End Messages for CreateRoundtable ---
-
 service CommunityService {
-  rpc ListRoundtables(ListRoundtablesRequest) returns (ListRoundtablesResponse);
-  // New RPC method for creating roundtables
-  rpc CreateRoundtable(CreateRoundtableRequest) returns (CreateRoundtableResponse);
+  // RPC methods previously here have been removed.
 }

--- a/src/Services/Master/master.proto
+++ b/src/Services/Master/master.proto
@@ -7,9 +7,75 @@ option csharp_namespace = "SurveyService.Master";
 service MasterService {
   // Define RPC methods here in the future
   rpc GetStatus (GetStatusRequest) returns (GetStatusResponse);
+  rpc GetRoundtable (GetRoundtableRequest) returns (GetRoundtableResponse); // Existing
+  rpc ListRoundtables(ListRoundtablesRequest) returns (ListRoundtablesResponse); // New
+  rpc CreateRoundtable(CreateRoundtableRequest) returns (CreateRoundtableResponse); // New
 }
 
 message GetStatusRequest {}
 message GetStatusResponse {
   string status = 1;
+}
+
+// New enum and message definitions
+enum RoundtableStatus {
+  ROUNDTABLE_STATUS_UNSPECIFIED = 0;
+  ACTIVE = 1;
+  INACTIVE = 2;
+  ALL = 3;
+}
+
+message UserDetails {
+  string user_id = 1;
+  string name = 2;
+  bool is_primary = 3;
+}
+
+message Roundtable {
+  string id = 1;                        // Existing
+  string name = 2;                      // Existing
+  string description = 3;               // Existing
+  RoundtableStatus status = 4;          // New
+  int32 clients_with_access_count = 5; // New
+  string abbreviation = 6;              // New
+  repeated string client_ids = 7;       // New
+  UserDetails director_details = 8;     // New
+  repeated UserDetails associate_details = 9; // New
+}
+
+message ListRoundtablesRequest {
+  string search_query = 1;
+  RoundtableStatus status_filter = 2;
+  int32 page_size = 3;
+  string page_token = 4;
+}
+
+message ListRoundtablesResponse {
+  repeated Roundtable roundtables = 1;
+  string next_page_token = 2;
+  int32 total_size = 3;
+}
+
+message GetRoundtableRequest {
+  string roundtable_id = 1;
+}
+
+message GetRoundtableResponse {
+  Roundtable roundtable = 1;
+}
+
+message CreateRoundtableRequest {
+  string name = 1;
+  string abbreviation = 2;
+  bool is_active = 3;
+  string description = 4;
+  repeated string client_ids = 5;
+  repeated string director_user_ids = 6;
+  repeated string associate_user_ids = 7;
+  string primary_director_user_id = 8;
+  string primary_associate_user_id = 9;
+}
+
+message CreateRoundtableResponse {
+  Roundtable roundtable = 1;
 }


### PR DESCRIPTION
This change centralizes Roundtable functionality within the MasterService.

Key changes:
- Removed Roundtable message definitions, RPCs (ListRoundtables, CreateRoundtable), and related enums/messages from `community.proto`.
- Removed corresponding C# implementation logic for Roundtables from `CommunityServiceImplementation.cs`.
- Augmented `master.proto` to include comprehensive Roundtable message definitions (Roundtable, UserDetails, RoundtableStatus), and RPCs (GetRoundtable, ListRoundtables, CreateRoundtable) within MasterService.
- Neutralized tests in `CommunityServiceTests.cs` by removing Roundtable-specific tests, as the functionality was moved. These tests should be migrated to MasterService in the future.
- Updated `README.md` to reflect that MasterService is now responsible for managing Roundtables.

This addresses your requirement to make Roundtables a part of the masters module.